### PR TITLE
Automated Changelog Entry for 0.1.1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,18 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.1
+
+([Full Changelog](https://github.com/DerThorsten/jupyter_wren_syntax/compare/0.1.0...e0a9e0141f5c9fbcbb328ae66373926f5adfad36))
+
+### Maintenance and upkeep improvements
+
+- Clean [#1](https://github.com/DerThorsten/jupyter_wren_syntax/pull/1) ([@DerThorsten](https://github.com/DerThorsten))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/DerThorsten/jupyter_wren_syntax/graphs/contributors?from=2021-10-01&to=2021-10-21&type=c))
+
+[@DerThorsten](https://github.com/search?q=repo%3ADerThorsten%2Fjupyter_wren_syntax+involves%3ADerThorsten+updated%3A2021-10-01..2021-10-21&type=Issues) | [@jtpio](https://github.com/search?q=repo%3ADerThorsten%2Fjupyter_wren_syntax+involves%3Ajtpio+updated%3A2021-10-01..2021-10-21&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.1.1 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | DerThorsten/jupyter_wren_syntax  |
| Branch  | main  |
| Version Spec | 0.1.1 |
| Since | 0.1.0 |