### PR TITLE
Remove console.log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,8 +81,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
   autoStart: true,
   requires: [ICodeMirror],
   activate: (app: JupyterFrontEnd, codeMirror: ICodeMirror) => {
-    console.log('JupyterLab extension jupyter-wren-syntax is activated!');
-
     registerWrenFileType(app);
     defineWrenCodeMirrorMode(codeMirror.CodeMirror);
   }


### PR DESCRIPTION
Remove the `console.log` that was logging `JupyterLab extension jupyter-wren-syntax is activated!`.